### PR TITLE
Changes README to https to avoid auth errors

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ Do a Wikirun directly from your terminal ( assuming you use Linux or Mac )!<br /
 Since I use Debian, I can only provide instructions for Debian-based distros.
 ```bash
 # Clone the repo
-git clone git@github.com:sadboyzvone/wikirider.git
+git clone https://github.com/sadboyzvone/wikirider.git
 # Run setup.sh
 cd wikirider && ./setup.sh
 # Activate virtualenv

--- a/README_RS.md
+++ b/README_RS.md
@@ -7,7 +7,7 @@ Odradite Wikirun direktno iz vašeg terminala ( podrazumevajući da koristite Li
 Budući da koristim Debian, mogu da pružim pomoć samo za sisteme bazirane na Debian-u.
 ```bash
 # Klonirajte repo
-git clone git@github.com:sadboyzvone/wikirider.git
+git clone https://github.com/sadboyzvone/wikirider.git
 # Pokrenite setup.sh
 cd wikirider && ./setup.sh
 # Aktivirajte virtualenv

--- a/README_TR.txt
+++ b/README_TR.txt
@@ -6,7 +6,7 @@ Kurulum
 Debian kullandigim icin, sadece Debian temelli sürümler icin kurulum adimlarini yazdim.
 
 #Repoyu kopyala
-git clone git@github.com:sadboyzvone/wikirider.git
+git clone https://github.com/sadboyzvone/wikirider.git
 #Sanal ortami kur
 sudo pip install virtualenv
 #Bir adet sanal ortam yarat


### PR DESCRIPTION
I believe this is default and recommended way to clone stuff from GH