### PR TITLE
Fix TabError on line 58

### DIFF
--- a/src/wikirider.py
+++ b/src/wikirider.py
@@ -55,7 +55,7 @@ class WikiRider(object):
         """Scrape html soup from next url"""
         try:
             self.html_source = Bs(req.get(self.next_url).content, 'lxml')
-	    return True
+            return True
         except req.RequestException:
             self.print_connection_error()
             return False


### PR DESCRIPTION
Cloning the repo, installing it and attempting to run it results in a TabError on line 58:
`TabError: inconsistent use of tabs and spaces in indentation`
This is because the line started with a tab worth 8 spaces followed by 4 spaces.

