### PR TITLE
fix indentation

### DIFF
--- a/src/wikirider.py
+++ b/src/wikirider.py
@@ -15,7 +15,6 @@ class WikiRider(object):
 
     def __init__(self, starting_url, depth):
         """WikiRider constructor
-
         Parameters
         ----------
         starting_url : str
@@ -33,7 +32,6 @@ class WikiRider(object):
 
     def run(self):
         """Do a run across wikipedia articles
-
         Yields
         ------
         WikiRider
@@ -55,7 +53,7 @@ class WikiRider(object):
         """Scrape html soup from next url"""
         try:
             self.html_source = Bs(req.get(self.next_url).content, 'lxml')
-	    return True
+            return True
         except req.RequestException:
             self.print_connection_error()
             return False


### PR DESCRIPTION
got an error while installing:
```
Traceback (most recent call last):
  File "./wikirun.py", line 2, in <module>
    from src.app import TerminalApp
  File "/home/<>/wikirider/src/app.py", line 4, in <module>
    from src.wikirider import WikiRider
  File "/home/<>/wikirider/src/wikirider.py", line 58
    return True
              ^
TabError: inconsistent use of tabs and spaces in indentation```
so I thought I can fix it :shrug: