### PR TITLE
Small bugfixes + added new functionality to setup script

### DIFF
--- a/setup.sh
+++ b/setup.sh
@@ -2,11 +2,35 @@
 
 echo -e "\e[1;32mInstalling wikirider...\e[0m"
 
-if pip install virtualenv && virtualenv .env && source $(pwd)/.env/bin/activate && pip install -r requirements.txt;
-then
+CUR_DIR=$(pwd)
+
+# if an arg is passed, use this as install location
+if  [ "$1" ] ; then
+    INSTALL_LOC=$1
+    rsync -a --exclude=.* $CUR_DIR $INSTALL_LOC
+else
+    set INSTALL_LOC=$CUR_DIR
+fi
+
+FULL_LOC=$INSTALL_LOC/wikirider
+cd $FULL_LOC
+
+echo -e "\e[1;32mInstall location is $FULL_LOC"
+
+if $(hash pip 2>/dev/null); then
+    PIP="pip"
+elif $(hash pip3 2>/dev/null); then
+    PIP="pip3"
+else
+    echo -e "\e[1;31mpip is not currently installed, please install it\e[0m"
+    exit 1
+fi
+
+if $PIP install virtualenv && virtualenv .env && source $(pwd)/.env/bin/activate && $PIP install -r requirements.txt; then
     echo -e "\e[1;32mInstallation complete!"
-    echo -e "To run wikirider, do \e[0;33m'source .env/bin/activate && python main.py'\e[1;32m!"
+    echo -e "To run wikirider, do \e[0;33m'cd $FULL_LOC; source .env/bin/activate && python wikirun.py'\e[1;32m!"
     echo -e "Don't forget to do \e[0;33m'deactivate'\e[1;32m after you're done to exit the virtualenv!\e[0m"
 else
     echo -e "\e[1;31mSome errors occured! Look up to see what went wrong.\e[0m"
 fi
+cd $CUR_DIR

--- a/src/wikirider.py
+++ b/src/wikirider.py
@@ -42,11 +42,11 @@ class WikiRider(object):
         if self.depth_counter < self.depth:
             self.visited_urls.append(self.next_url)
             if self._scrape_html_source() != False:
-            	yield self
-            	self._search_urls()
-            	self._set_destination()
-            	for rider_state in self.run():
-                	yield self
+                yield self
+                self._search_urls()
+                self._set_destination()
+                for rider_state in self.run():
+                    yield self
 
     def print_connection_error(self):
         print('Failed to connect to the Wiki (check your URL!)')
@@ -55,7 +55,7 @@ class WikiRider(object):
         """Scrape html soup from next url"""
         try:
             self.html_source = Bs(req.get(self.next_url).content, 'lxml')
-	    return True
+            return True
         except req.RequestException:
             self.print_connection_error()
             return False


### PR DESCRIPTION
setup.sh now allows the user to invoke with an additional argument of install directory. If they do this
    then the non-hidden project files are copied to this directory, and the venv is created there.
    additionally, the run commands were updated to no longer reference main.py (doesn't exist)

src/wikirider.py had some inconsistent spacing and tabs which was causing run errors - fixed these.